### PR TITLE
Lower memory usage from compiling and running binaries

### DIFF
--- a/cmd/editor/ide/settings.go
+++ b/cmd/editor/ide/settings.go
@@ -80,7 +80,8 @@ func newSettingsDropdown(attachTo *dom.Element) *dropdown {
 			destroyMount(cache)
 		}
 	})
-	listenButton("reload go install", "Reinstall Go and reload?", func() {
+	listenButton("reload programs", "Reinstall programs and reload?", func() {
+		_, _ = destroyMount("/bin").Await()
 		_, _ = destroyMount(goInstallPath).Await()
 		dom.Reload()
 	})

--- a/cmd/editor/ide/settings.html
+++ b/cmd/editor/ide/settings.html
@@ -1,5 +1,5 @@
 <ul>
 	<li><button title="clean build cache">Clean build cache</button></li>
-	<li><button class="danger" title="reload go install">Reload Go installation</button></li>
+	<li><button class="danger" title="reload programs">Reload programs</button></li>
 	<li><button class="danger" title="reset">Reset</button></li>
 </ul>

--- a/cmd/editor/ide/tab.go
+++ b/cmd/editor/ide/tab.go
@@ -67,6 +67,8 @@ func (t *Tab) watchTitles(ctx context.Context, tabber Tabber) {
 		case title, ok := <-titles:
 			if ok {
 				t.title.SetInnerText(title)
+			} else {
+				t.Close()
 			}
 		}
 	}

--- a/cmd/editor/ide/window.go
+++ b/cmd/editor/ide/window.go
@@ -98,26 +98,28 @@ func New(elem *dom.Element, editorBuilder EditorBuilder, consoleBuilder ConsoleB
 			return
 		}
 
-		src, err := ioutil.ReadFile(path)
-		if err != nil {
-			log.Errorf("Failed to read Go file %q: %v", path, err)
-			return
-		}
-		out, err := format.Source(src)
-		if err != nil {
-			log.Errorf("Failed to format Go file %q: %v", path, err)
-			return
-		}
-		err = ioutil.WriteFile(path, out, 0)
-		if err != nil {
-			log.Errorf("Failed to write Go file %q: %v", path, err)
-			return
-		}
-		err = editor.ReloadFile()
-		if err != nil {
-			log.Errorf("Failed to reload Go file %q: %v", path, err)
-			return
-		}
+		go func() {
+			src, err := ioutil.ReadFile(path)
+			if err != nil {
+				log.Errorf("Failed to read Go file %q: %v", path, err)
+				return
+			}
+			out, err := format.Source(src)
+			if err != nil {
+				log.Errorf("Failed to format Go file %q: %v", path, err)
+				return
+			}
+			err = ioutil.WriteFile(path, out, 0)
+			if err != nil {
+				log.Errorf("Failed to write Go file %q: %v", path, err)
+				return
+			}
+			err = editor.ReloadFile()
+			if err != nil {
+				log.Errorf("Failed to reload Go file %q: %v", path, err)
+				return
+			}
+		}()
 	})
 
 	controls := elem.QuerySelector(".controls")

--- a/cmd/editor/terminal/terminal.go
+++ b/cmd/editor/terminal/terminal.go
@@ -34,7 +34,13 @@ func (b *terminalBuilder) New(elem *dom.Element, rawName, name string, args ...s
 		xterm:     b.newXTermFunc.Invoke(elem),
 		titleChan: make(chan string, 1),
 	}
-	return term, term.start(rawName, name, args...)
+	go func() {
+		err := term.start(rawName, name, args...)
+		if err != nil {
+			log.Error("Failed to start terminal:", err)
+		}
+	}()
+	return term, nil
 }
 
 func (t *terminal) start(rawName, name string, args ...string) error {

--- a/http_get.go
+++ b/http_get.go
@@ -3,8 +3,6 @@
 package main
 
 import (
-	"io/ioutil"
-	"net/http"
 	"syscall/js"
 
 	"github.com/johnstarich/go-wasm/internal/blob"
@@ -15,23 +13,6 @@ import (
 
 var jsFetch = js.Global().Get("fetch")
 var uint8Array = js.Global().Get("Uint8Array")
-
-// httpGetGo uses significantly more memory converting from JS to Go, and then back again
-func httpGetGo(path string) (blob.Blob, error) {
-	resp, err := http.Get(path)
-	if err != nil {
-		return nil, err
-	}
-	defer resp.Body.Close()
-	if resp.StatusCode/100 != 2 { // not success
-		return nil, errors.New(resp.Status)
-	}
-	if contentType := resp.Header.Get("Content-Type"); contentType != "application/wasm" {
-		return nil, errors.New("Invalid content type for Wasm: " + contentType)
-	}
-	buf, err := ioutil.ReadAll(resp.Body)
-	return blob.NewFromBytes(buf), err
-}
 
 // httpGetFetch sticks to simple calls to the fetch API, then keeps the data inside a JS ArrayBuffer. Memory usage is lower than the "native" http package
 func httpGetFetch(path string) (_ blob.Blob, err error) {

--- a/http_get.go
+++ b/http_get.go
@@ -1,0 +1,51 @@
+// +build js
+
+package main
+
+import (
+	"errors"
+	"io/ioutil"
+	"net/http"
+	"syscall/js"
+
+	"github.com/johnstarich/go-wasm/internal/blob"
+	"github.com/johnstarich/go-wasm/internal/common"
+	"github.com/johnstarich/go-wasm/internal/promise"
+)
+
+var jsFetch = js.Global().Get("fetch")
+var uint8Array = js.Global().Get("Uint8Array")
+
+// httpGetGo uses significantly more memory converting from JS to Go, and then back again
+func httpGetGo(path string) (blob.Blob, error) {
+	resp, err := http.Get(path)
+	if err != nil {
+		return nil, err
+	}
+	defer resp.Body.Close()
+	if resp.StatusCode/100 != 2 { // not success
+		return nil, errors.New(resp.Status)
+	}
+	if contentType := resp.Header.Get("Content-Type"); contentType != "application/wasm" {
+		return nil, errors.New("Invalid content type for Wasm: " + contentType)
+	}
+	buf, err := ioutil.ReadAll(resp.Body)
+	return blob.NewFromBytes(buf), err
+}
+
+// httpGetFetch sticks to simple calls to the fetch API, then keeps the data inside a JS ArrayBuffer. Memory usage is lower than the "native" http package
+func httpGetFetch(path string) (_ blob.Blob, err error) {
+	defer common.CatchException(&err)
+	prom := jsFetch.Invoke(path)
+	result, err := promise.From(prom).Await()
+	if err != nil {
+		return nil, err
+	}
+
+	body, err := promise.From(result.(js.Value).Call("arrayBuffer")).Await()
+	if err != nil {
+		return nil, err
+	}
+	buf := uint8Array.New(body.(js.Value))
+	return blob.NewFromJS(buf)
+}

--- a/install.go
+++ b/install.go
@@ -6,6 +6,7 @@ import (
 	"errors"
 	"os"
 	"path/filepath"
+	"runtime"
 	"syscall/js"
 
 	"github.com/johnstarich/go-wasm/internal/interop"
@@ -42,6 +43,7 @@ func install(args []js.Value) error {
 	if err != nil {
 		return err
 	}
+	defer runtime.GC()
 	fs := process.Current().Files()
 	fd, err := fs.Open("/bin/"+command, os.O_CREATE|os.O_TRUNC|os.O_WRONLY, 0750)
 	if err != nil {

--- a/internal/blob/blob.go
+++ b/internal/blob/blob.go
@@ -4,6 +4,7 @@ type Blob interface {
 	jsExtensions
 	Bytes() []byte
 	Len() int
+	View(start, end int64) (Blob, error)
 	Slice(start, end int64) (Blob, error)
 	Set(w Blob, off int64) (n int, err error)
 	Grow(off int64) error

--- a/internal/blob/blob_js.go
+++ b/internal/blob/blob_js.go
@@ -81,12 +81,25 @@ func (b *blob) Len() int {
 	return int(b.length.Load())
 }
 
-func (b *blob) Slice(start, end int64) (_ Blob, returnedErr error) {
+func (b *blob) View(start, end int64) (_ Blob, returnedErr error) {
 	defer common.CatchException(&returnedErr)
 
 	if b.hasBytes.Load() {
 		buf := b.bytes.Load().([]byte)
 		return NewFromBytes(buf[start:end]), nil
+	}
+	buf := b.jsValue.Load().(js.Value)
+	return NewFromJS(buf.Call("subarray", start, end))
+}
+
+func (b *blob) Slice(start, end int64) (_ Blob, returnedErr error) {
+	defer common.CatchException(&returnedErr)
+
+	if b.hasBytes.Load() {
+		buf := b.bytes.Load().([]byte)
+		bufCopy := make([]byte, end-start)
+		copy(bufCopy, buf)
+		return NewFromBytes(bufCopy), nil
 	}
 	buf := b.jsValue.Load().(js.Value)
 	return NewFromJS(buf.Call("slice", start, end))

--- a/internal/blob/blob_js.go
+++ b/internal/blob/blob_js.go
@@ -44,7 +44,7 @@ func NewFromJS(buf js.Value) (Blob, error) {
 	return b, nil
 }
 
-func NewJSLength(length int) Blob {
+func NewWithLength(length int) Blob {
 	buf, err := NewFromJS(uint8Array.New(length))
 	if err != nil {
 		panic("blob: New empty array of correct type was rejected: " + err.Error())

--- a/internal/blob/blob_js.go
+++ b/internal/blob/blob_js.go
@@ -84,6 +84,9 @@ func (b *blob) Len() int {
 func (b *blob) View(start, end int64) (_ Blob, returnedErr error) {
 	defer common.CatchException(&returnedErr)
 
+	if start == 0 && end == b.length.Load() {
+		return b, nil
+	}
 	if b.hasBytes.Load() {
 		buf := b.bytes.Load().([]byte)
 		return NewFromBytes(buf[start:end]), nil

--- a/internal/blob/blob_other.go
+++ b/internal/blob/blob_other.go
@@ -12,6 +12,10 @@ func NewFromBytes(buf []byte) Blob {
 	return &blob{buf}
 }
 
+func NewWithLength(length int) Blob {
+	return NewFromBytes(make([]byte, length))
+}
+
 func (b *blob) Bytes() []byte {
 	return b.bytes
 }

--- a/internal/blob/blob_other.go
+++ b/internal/blob/blob_other.go
@@ -20,8 +20,14 @@ func (b *blob) Len() int {
 	return len(b.bytes)
 }
 
-func (b *blob) Slice(start, end int64) (_ Blob, err error) {
+func (b *blob) View(start, end int64) (_ Blob, err error) {
 	return NewFromBytes(b.bytes[start:end]), nil
+}
+
+func (b *blob) Slice(start, end int64) (_ Blob, err error) {
+	buf := make([]byte, end-start)
+	copy(buf, b.bytes)
+	return NewFromBytes(buf), nil
 }
 
 func (b *blob) Set(w Blob, off int64) (n int, err error) {

--- a/internal/fs/file_descriptors.go
+++ b/internal/fs/file_descriptors.go
@@ -167,10 +167,6 @@ func (f *FileDescriptors) Fstat(fd FID) (os.FileInfo, error) {
 	return fileDescriptor.file.Stat()
 }
 
-func (f *FileDescriptors) ReadFile(path string) ([]byte, error) {
-	return afero.ReadFile(filesystem, f.resolvePath(path))
-}
-
 func (f *FileDescriptors) ReadDir(path string) ([]os.FileInfo, error) {
 	return afero.ReadDir(filesystem, f.resolvePath(path))
 }

--- a/internal/fs/file_descriptors_js.go
+++ b/internal/fs/file_descriptors_js.go
@@ -1,0 +1,18 @@
+// +build js
+
+package fs
+
+import (
+	"syscall/js"
+)
+
+type wasmInstancer interface {
+	WasmInstance(path string, importObject js.Value) (js.Value, error)
+}
+
+func (f *FileDescriptors) WasmInstance(path string, importObject js.Value) (js.Value, error) {
+	if instancer, ok := filesystem.(wasmInstancer); ok {
+		return instancer.WasmInstance(f.resolvePath(path), importObject)
+	}
+	panic("Wasm Cache not initialized")
+}

--- a/internal/fs/fs.go
+++ b/internal/fs/fs.go
@@ -15,8 +15,16 @@ import (
 )
 
 var (
-	filesystem = mountfs.New(afero.NewMemMapFs())
+	filesystem rootFs = mountfs.New(afero.NewMemMapFs())
 )
+
+type rootFs interface {
+	afero.Fs
+	afero.Lstater
+	Mounts() map[string]string
+	DestroyMount(string) error
+	Mount(string, afero.Fs) error
+}
 
 func Mounts() (pathsToFSName map[string]string) {
 	return filesystem.Mounts()

--- a/internal/fs/fs.go
+++ b/internal/fs/fs.go
@@ -24,6 +24,7 @@ type rootFs interface {
 	Mounts() map[string]string
 	DestroyMount(string) error
 	Mount(string, afero.Fs) error
+	FSForPath(string) afero.Fs
 }
 
 func Mounts() (pathsToFSName map[string]string) {

--- a/internal/fs/read.go
+++ b/internal/fs/read.go
@@ -44,7 +44,7 @@ func (f *FileDescriptors) ReadFile(path string) (blob.Blob, error) {
 		return nil, err
 	}
 
-	buf := blob.NewJSLength(int(info.Size()))
+	buf := blob.NewWithLength(int(info.Size()))
 	_, err = f.Read(fd, buf, 0, buf.Len(), nil)
 	return buf, err
 }

--- a/internal/fs/read.go
+++ b/internal/fs/read.go
@@ -31,3 +31,20 @@ func (f *FileDescriptors) Read(fd FID, buffer blob.Blob, offset, length int, pos
 	}
 	return
 }
+
+func (f *FileDescriptors) ReadFile(path string) (blob.Blob, error) {
+	fd, err := f.Open(path, 0, 0)
+	if err != nil {
+		return nil, err
+	}
+	defer f.Close(fd)
+
+	info, err := f.Fstat(fd)
+	if err != nil {
+		return nil, err
+	}
+
+	buf := blob.NewJSLength(int(info.Size()))
+	_, err = f.Read(fd, buf, 0, buf.Len(), nil)
+	return buf, err
+}

--- a/internal/fs/wasm_cache.go
+++ b/internal/fs/wasm_cache.go
@@ -1,0 +1,263 @@
+// +build js
+
+package fs
+
+import (
+	"io"
+	"os"
+	"syscall/js"
+	"time"
+
+	"github.com/johnstarich/go-wasm/internal/blob"
+	"github.com/johnstarich/go-wasm/internal/fsutil"
+	"github.com/johnstarich/go-wasm/internal/indexeddb"
+	"github.com/johnstarich/go-wasm/internal/interop"
+	"github.com/johnstarich/go-wasm/internal/promise"
+	"github.com/johnstarich/go-wasm/log"
+	"github.com/spf13/afero"
+)
+
+var jsWasm = js.Global().Get("WebAssembly")
+
+const (
+	wasmCacheDB      = "wasmModules"
+	wasmCacheVersion = 1
+	wasmCacheStore   = "modules"
+)
+
+type wasmCacheFs struct {
+	rootFs
+	db       *indexeddb.DB
+	jsPaths  interop.StringCache
+	memCache map[string]js.Value
+	idbFound map[string]bool
+}
+
+func init() {
+	go initWasmCache()
+}
+
+func initWasmCache() {
+	fs, err := newWasmCacheFs(filesystem)
+	if err != nil {
+		log.Error("Failed to enable Wasm Module cache: ", err)
+	} else {
+		filesystem = fs
+	}
+}
+
+func newWasmCacheFs(underlying rootFs) (*wasmCacheFs, error) {
+	db, err := indexeddb.New(wasmCacheDB, wasmCacheVersion, func(db *indexeddb.DB, oldVersion, newVersion int) error {
+		_, err := db.CreateObjectStore(wasmCacheStore, indexeddb.ObjectStoreOptions{})
+		return err
+	})
+	return &wasmCacheFs{
+		rootFs:   underlying,
+		db:       db,
+		memCache: make(map[string]js.Value),
+		idbFound: make(map[string]bool),
+	}, err
+}
+
+func (w *wasmCacheFs) readFile(path string) (blob.Blob, error) {
+	path = fsutil.NormalizePath(path)
+	f, err := w.Open(path)
+	if err != nil {
+		return nil, err
+	}
+	defer f.Close()
+
+	info, err := f.Stat()
+	if err != nil {
+		return nil, err
+	}
+
+	buf, _, err := blob.Read(f, int(info.Size()))
+	if err == io.EOF {
+		err = nil
+	}
+	return buf, err
+}
+
+func (w *wasmCacheFs) WasmInstance(path string, importObject js.Value) (js.Value, error) {
+	path = fsutil.NormalizePath(path)
+	log.Debug("Checking wasm instance cache")
+	module, memCacheHit := w.memCache[path]
+	if memCacheHit {
+		log.Debug("memCache hit: ", path)
+	} else {
+		log.Debug("memCache miss: ", path)
+		dbFound, dbChecked := w.idbFound[path]
+		if dbFound || !dbChecked {
+			moduleBlob, err := w.getModuleBytes(path)
+			if err != nil {
+				log.Debug("Failed to look up module at path: ", path)
+				return js.Value{}, err
+			}
+			if moduleBlob != nil {
+				module = moduleBlob.JSValue()
+			}
+		}
+	}
+
+	dbCacheHit := module.Truthy()
+	if dbCacheHit {
+		log.Debug("dbCache hit: ", path, module.Length())
+	} else {
+		log.Debug("dbCache miss: ", path)
+		moduleBlob, err := w.readFile(path)
+		if err != nil {
+			log.Debug("reading file failed: ", path)
+			return js.Value{}, err
+		}
+		module = moduleBlob.JSValue()
+	}
+
+	instantiatePromise := promise.From(jsWasm.Call("instantiate", module, importObject))
+	instanceInterface, err := instantiatePromise.Await()
+	if err != nil {
+		return js.Value{}, err
+	}
+	result := instanceInterface.(js.Value)
+
+	log.Debug("successfully instantiated module: ", path)
+	if memCacheHit {
+		// if memCacheHit, then module is already compiled
+		// so return value is only an Instance, not a ResultObject
+		return result, nil
+	}
+
+	w.memCache[path] = result.Get("module") // save compiled module for reuse
+	instance := result.Get("instance")
+	if !dbCacheHit {
+		// save module to IDB
+		return instance, w.setModule(path, module)
+	}
+	return instance, nil
+}
+
+func (w *wasmCacheFs) dropModuleCache(path string) error {
+	path = fsutil.NormalizePath(path)
+
+	_, memCacheHit := w.memCache[path]
+	if memCacheHit {
+		delete(w.memCache, path)
+	}
+
+	dbCacheHit := w.idbFound[path]
+	if dbCacheHit {
+		err := w.deleteModule(path)
+		if err != nil {
+			return err
+		}
+		delete(w.idbFound, path)
+	}
+	return nil
+}
+
+func (w *wasmCacheFs) deleteModule(path string) error {
+	txn, err := w.db.Transaction(indexeddb.TransactionReadWrite, wasmCacheStore)
+	if err != nil {
+		return err
+	}
+	store, err := txn.ObjectStore(wasmCacheStore)
+	if err != nil {
+		return err
+	}
+	req, err := store.Delete(w.jsPaths.Value(path))
+	if err != nil {
+		return err
+	}
+	_, err = req.Await()
+	return err
+}
+
+func (w *wasmCacheFs) setModule(path string, module js.Value) error {
+	path = fsutil.NormalizePath(path)
+	txn, err := w.db.Transaction(indexeddb.TransactionReadWrite, wasmCacheStore)
+	if err != nil {
+		return err
+	}
+	store, err := txn.ObjectStore(wasmCacheStore)
+	if err != nil {
+		return err
+	}
+	req, err := store.Put(w.jsPaths.Value(path), module.JSValue())
+	if err != nil {
+		return err
+	}
+	_, err = req.Await()
+	if err == nil {
+		w.idbFound[path] = true
+	}
+	return err
+}
+
+func (w *wasmCacheFs) getModuleBytes(path string) (blob.Blob, error) {
+	path = fsutil.NormalizePath(path)
+	txn, err := w.db.Transaction(indexeddb.TransactionReadOnly, wasmCacheStore)
+	if err != nil {
+		return nil, err
+	}
+	store, err := txn.ObjectStore(wasmCacheStore)
+	if err != nil {
+		return nil, err
+	}
+	req, err := store.Get(w.jsPaths.Value(path))
+	if err != nil {
+		return nil, err
+	}
+	jsBytes, err := req.Await()
+	if err != nil || jsBytes.IsUndefined() {
+		return nil, err
+	}
+	w.idbFound[path] = true
+	return blob.NewFromJS(jsBytes)
+}
+
+func (w *wasmCacheFs) Create(name string) (afero.File, error) {
+	if err := w.dropModuleCache(fsutil.NormalizePath(name)); err != nil {
+		return nil, err
+	}
+	return w.rootFs.Create(name)
+}
+
+func (w *wasmCacheFs) OpenFile(name string, flag int, perm os.FileMode) (afero.File, error) {
+	if flag != os.O_RDONLY {
+		err := w.dropModuleCache(fsutil.NormalizePath(name))
+		if err != nil {
+			return nil, err
+		}
+	}
+	return w.rootFs.OpenFile(name, flag, perm)
+}
+
+func (w *wasmCacheFs) Remove(name string) error {
+	if err := w.dropModuleCache(fsutil.NormalizePath(name)); err != nil {
+		return err
+	}
+	return w.rootFs.Remove(name)
+}
+
+func (w *wasmCacheFs) RemoveAll(path string) error {
+	// TODO is there a performant way to remove modules recursively?
+	if err := w.dropModuleCache(fsutil.NormalizePath(path)); err != nil {
+		return err
+	}
+	return w.rootFs.RemoveAll(path)
+}
+
+func (w *wasmCacheFs) Rename(oldname, newname string) error {
+	// TODO maybe preserve oldname's module somehow?
+	if err := w.dropModuleCache(fsutil.NormalizePath(oldname)); err != nil {
+		return err
+	}
+	if err := w.dropModuleCache(fsutil.NormalizePath(newname)); err != nil {
+		return err
+	}
+	return w.rootFs.Rename(oldname, newname)
+}
+
+func (w *wasmCacheFs) Chtimes(name string, atime time.Time, mtime time.Time) error {
+	return w.rootFs.Chtimes(name, atime, mtime)
+}

--- a/internal/fs/wasm_cache.go
+++ b/internal/fs/wasm_cache.go
@@ -261,3 +261,25 @@ func (w *wasmCacheFs) Rename(oldname, newname string) error {
 func (w *wasmCacheFs) Chtimes(name string, atime time.Time, mtime time.Time) error {
 	return w.rootFs.Chtimes(name, atime, mtime)
 }
+
+func (w *wasmCacheFs) DestroyMount(path string) error {
+	txn, err := w.db.Transaction(indexeddb.TransactionReadWrite, wasmCacheStore)
+	if err != nil {
+		return err
+	}
+	store, err := txn.ObjectStore(wasmCacheStore)
+	if err != nil {
+		return err
+	}
+	req, err := store.Clear()
+	if err != nil {
+		return err
+	}
+	_, err = req.Await()
+	if err != nil {
+		return err
+	}
+	w.idbFound = make(map[string]bool)
+	w.memCache = make(map[string]js.Value)
+	return w.rootFs.DestroyMount(path)
+}

--- a/internal/fs/wasm_cache.go
+++ b/internal/fs/wasm_cache.go
@@ -11,7 +11,6 @@ import (
 
 	"github.com/johnstarich/go-wasm/internal/blob"
 	"github.com/johnstarich/go-wasm/internal/fsutil"
-	"github.com/johnstarich/go-wasm/internal/interop"
 	"github.com/johnstarich/go-wasm/internal/promise"
 	"github.com/johnstarich/go-wasm/log"
 	"github.com/spf13/afero"
@@ -19,15 +18,8 @@ import (
 
 var jsWasm = js.Global().Get("WebAssembly")
 
-const (
-	wasmCacheDB      = "wasmModules"
-	wasmCacheVersion = 1
-	wasmCacheStore   = "modules"
-)
-
 type wasmCacheFs struct {
 	rootFs
-	jsPaths  interop.StringCache
 	memCache map[string]js.Value
 }
 

--- a/internal/fs/wasm_cache.go
+++ b/internal/fs/wasm_cache.go
@@ -5,6 +5,7 @@ package fs
 import (
 	"io"
 	"os"
+	"strings"
 	"syscall/js"
 	"time"
 
@@ -41,6 +42,10 @@ func initWasmCache() {
 	} else {
 		filesystem = fs
 	}
+}
+
+func shouldCache(path string) bool {
+	return strings.HasPrefix(path, "/usr/local/go/")
 }
 
 func newWasmCacheFs(underlying rootFs) (*wasmCacheFs, error) {
@@ -103,7 +108,9 @@ func (w *wasmCacheFs) WasmInstance(path string, importObject js.Value) (js.Value
 		return result, nil
 	}
 
-	w.memCache[path] = result.Get("module") // save compiled module for reuse
+	if shouldCache(path) {
+		w.memCache[path] = result.Get("module") // save compiled module for reuse
+	}
 	return result.Get("instance"), nil
 }
 

--- a/internal/fs/write.go
+++ b/internal/fs/write.go
@@ -20,7 +20,7 @@ func (f *FileDescriptors) Write(fd FID, buffer blob.Blob, offset, length int, po
 			return 0, err
 		}
 	}
-	dataToCopy, err := buffer.Slice(int64(offset), int64(offset+length))
+	dataToCopy, err := buffer.View(int64(offset), int64(offset+length))
 	if err != nil {
 		return 0, err
 	}

--- a/internal/interop/funcs.go
+++ b/internal/interop/funcs.go
@@ -86,15 +86,6 @@ func handlePanic(skipPanicLines int) {
 	defaultHandlePanic(skipPanicLines+1, r)
 }
 
-func handlePanicFunc(skipPanicLines int, fn func(interface{})) {
-	r := recover()
-	if r == nil {
-		return
-	}
-	defaultHandlePanic(skipPanicLines+1, r)
-	fn(r)
-}
-
 func defaultHandlePanic(skipPanicLines int, r interface{}) {
 	stack := string(debug.Stack())
 	for iter := 0; iter < skipPanicLines; iter++ {

--- a/internal/mountfs/fs.go
+++ b/internal/mountfs/fs.go
@@ -86,7 +86,7 @@ func (m *Fs) Mount(path string, fs afero.Fs) error {
 	return nil
 }
 
-func (m *Fs) fsForPath(path string) afero.Fs {
+func (m *Fs) FSForPath(path string) afero.Fs {
 	return mountedFs{m.mountForPath(path)}
 }
 
@@ -102,23 +102,23 @@ func (m *Fs) mountForPath(path string) mount {
 }
 
 func (m *Fs) Create(name string) (afero.File, error) {
-	return m.fsForPath(name).Create(name)
+	return m.FSForPath(name).Create(name)
 }
 
 func (m *Fs) Mkdir(name string, perm os.FileMode) error {
-	return m.fsForPath(name).Mkdir(name, perm)
+	return m.FSForPath(name).Mkdir(name, perm)
 }
 
 func (m *Fs) MkdirAll(path string, perm os.FileMode) error {
-	return m.fsForPath(path).MkdirAll(path, perm)
+	return m.FSForPath(path).MkdirAll(path, perm)
 }
 
 func (m *Fs) Open(name string) (afero.File, error) {
-	return m.fsForPath(name).Open(name)
+	return m.FSForPath(name).Open(name)
 }
 
 func (m *Fs) OpenFile(name string, flag int, perm os.FileMode) (afero.File, error) {
-	return m.fsForPath(name).OpenFile(name, flag, perm)
+	return m.FSForPath(name).OpenFile(name, flag, perm)
 }
 
 func (m *Fs) Remove(name string) error {
@@ -130,14 +130,14 @@ func (m *Fs) Remove(name string) error {
 }
 
 func (m *Fs) RemoveAll(path string) error {
-	return m.fsForPath(path).RemoveAll(path)
+	return m.FSForPath(path).RemoveAll(path)
 }
 
 func (m *Fs) Rename(oldname, newname string) error {
 	m.mu.RLock()
-	oldFs := m.fsForPath(oldname)
+	oldFs := m.FSForPath(oldname)
 	oldMount := m.mountForPath(oldname)
-	newFs := m.fsForPath(newname)
+	newFs := m.FSForPath(newname)
 	newMount := m.mountForPath(newname)
 	m.mu.RUnlock()
 
@@ -174,7 +174,7 @@ func (m *Fs) Rename(oldname, newname string) error {
 }
 
 func (m *Fs) Stat(name string) (os.FileInfo, error) {
-	return m.fsForPath(name).Stat(name)
+	return m.FSForPath(name).Stat(name)
 }
 
 func (m *Fs) Name() string {
@@ -182,15 +182,15 @@ func (m *Fs) Name() string {
 }
 
 func (m *Fs) Chmod(name string, mode os.FileMode) error {
-	return m.fsForPath(name).Chmod(name, mode)
+	return m.FSForPath(name).Chmod(name, mode)
 }
 
 func (m *Fs) Chtimes(name string, atime time.Time, mtime time.Time) error {
-	return m.fsForPath(name).Chtimes(name, atime, mtime)
+	return m.FSForPath(name).Chtimes(name, atime, mtime)
 }
 
 func (m *Fs) LstatIfPossible(name string) (os.FileInfo, bool, error) {
-	fs := m.fsForPath(name)
+	fs := m.FSForPath(name)
 	if lstater, ok := fs.(afero.Lstater); ok {
 		return lstater.LstatIfPossible(name)
 	}

--- a/internal/mountfs/fs.go
+++ b/internal/mountfs/fs.go
@@ -98,7 +98,7 @@ func (m *Fs) mountForPath(path string) mount {
 			return mounts[i]
 		}
 	}
-	return mounts[0] // should be impossible to hit this line, but always fall back to defaultFs mount
+	return mounts[0] // always fall back to defaultFs mount
 }
 
 func (m *Fs) Create(name string) (afero.File, error) {

--- a/internal/process/process_js.go
+++ b/internal/process/process_js.go
@@ -9,8 +9,7 @@ import (
 )
 
 var (
-	jsGo   = js.Global().Get("Go")
-	jsWasm = js.Global().Get("WebAssembly")
+	jsGo = js.Global().Get("Go")
 )
 
 func (p *process) JSValue() js.Value {

--- a/internal/process/wasm.go
+++ b/internal/process/wasm.go
@@ -9,7 +9,6 @@ import (
 	"syscall/js"
 	"time"
 
-	"github.com/johnstarich/go-wasm/internal/blob"
 	"github.com/johnstarich/go-wasm/internal/interop"
 	"github.com/johnstarich/go-wasm/internal/promise"
 	"github.com/johnstarich/go-wasm/log"
@@ -50,13 +49,11 @@ func (p *process) newWasmInstance(path string, importObject js.Value) (js.Value,
 		}
 	}
 
-	// TODO switch to reading with blob package
 	wasm, err := p.Files().ReadFile(path)
 	if err != nil {
 		return js.Value{}, err
 	}
-	b := blob.NewFromBytes(wasm)
-	instantiatePromise := promise.From(jsWasm.Call("instantiate", b, importObject))
+	instantiatePromise := promise.From(jsWasm.Call("instantiate", wasm, importObject))
 	instantiateResult, err := instantiatePromise.Await()
 	if err != nil {
 		return js.Value{}, err

--- a/internal/process/wasm.go
+++ b/internal/process/wasm.go
@@ -50,6 +50,9 @@ func (p *process) startWasmPromise(path string, exitChan chan<- int) (promise.Pr
 			if resumeFuncPtr != nil {
 				resumeFuncPtr.Release()
 			}
+			// TODO free the whole goInstance to fix garbage issues entirely. Freeing individual properties appears to work for now, but is ultimately a bad long-term solution because memory still accumulates.
+			goInstance.Set("mem", js.Null())
+			goInstance.Set("importObject", js.Null())
 		}()
 		if len(args) == 0 {
 			exitChan <- -1

--- a/internal/rwonly/read_only_blob.go
+++ b/internal/rwonly/read_only_blob.go
@@ -1,5 +1,3 @@
-// +build js
-
 package rwonly
 
 import (

--- a/internal/rwonly/read_only_blob.go
+++ b/internal/rwonly/read_only_blob.go
@@ -1,0 +1,48 @@
+// +build js
+
+package rwonly
+
+import (
+	"os"
+	"syscall"
+
+	"github.com/johnstarich/go-wasm/internal/blob"
+	"github.com/spf13/afero"
+)
+
+type blobFileReader interface {
+	afero.File
+	blob.Reader
+	blob.ReaderAt
+}
+
+type blobReadOnlyFile struct {
+	blobFileReader
+}
+
+func BlobReadOnly(file afero.File) afero.File {
+	if blobFile, ok := file.(blobFileReader); ok {
+		return &blobReadOnlyFile{blobFile}
+	}
+	return ReadOnly(file)
+}
+
+func (r *blobReadOnlyFile) writeErr(op string) error {
+	return &os.PathError{Op: op, Path: r.Name(), Err: syscall.EBADF}
+}
+
+func (r *blobReadOnlyFile) Write(p []byte) (n int, err error) {
+	return 0, r.writeErr("write")
+}
+
+func (r *blobReadOnlyFile) WriteAt(p []byte, off int64) (n int, err error) {
+	return 0, r.writeErr("writeat")
+}
+
+func (r *blobReadOnlyFile) Truncate(size int64) error {
+	return r.writeErr("truncate")
+}
+
+func (r *blobReadOnlyFile) WriteString(s string) (ret int, err error) {
+	return 0, r.writeErr("write")
+}

--- a/internal/rwonly/write_only_blob.go
+++ b/internal/rwonly/write_only_blob.go
@@ -1,0 +1,38 @@
+package rwonly
+
+import (
+	"os"
+	"syscall"
+
+	"github.com/johnstarich/go-wasm/internal/blob"
+	"github.com/spf13/afero"
+)
+
+type blobFileWriter interface {
+	afero.File
+	blob.Writer
+	blob.WriterAt
+}
+
+type blobWriteOnlyFile struct {
+	blobFileWriter
+}
+
+func BlobWriteOnly(file afero.File) afero.File {
+	if blobFile, ok := file.(blobFileWriter); ok {
+		return &blobWriteOnlyFile{blobFile}
+	}
+	return WriteOnly(file)
+}
+
+func (w *blobWriteOnlyFile) readErr(op string) error {
+	return &os.PathError{Op: op, Path: w.Name(), Err: syscall.EBADF}
+}
+
+func (w *blobWriteOnlyFile) Read(p []byte) (n int, err error) {
+	return 0, w.readErr("read")
+}
+
+func (w *blobWriteOnlyFile) ReadAt(p []byte, off int64) (n int, err error) {
+	return 0, w.readErr("readat")
+}

--- a/internal/storer/file.go
+++ b/internal/storer/file.go
@@ -11,10 +11,12 @@ import (
 
 	"github.com/johnstarich/go-wasm/internal/blob"
 	"github.com/pkg/errors"
+	"github.com/spf13/afero"
 	"go.uber.org/atomic"
 )
 
 var (
+	_ afero.File    = &File{}
 	_ blob.Reader   = &File{}
 	_ blob.ReaderAt = &File{}
 	_ blob.Writer   = &File{}

--- a/internal/storer/file.go
+++ b/internal/storer/file.go
@@ -149,7 +149,7 @@ func (f *File) ReadBlobAt(length int, off int64) (blob blob.Blob, n int, err err
 	if end > max {
 		end = max
 	}
-	blob, err = f.Data().Slice(off, end)
+	blob, err = f.Data().View(off, end)
 	if err != nil {
 		return nil, 0, err
 	}

--- a/internal/storer/fs.go
+++ b/internal/storer/fs.go
@@ -160,7 +160,7 @@ func (fs *Fs) OpenFile(name string, flag int, perm os.FileMode) (afFile afero.Fi
 	case flag&os.O_RDWR != 0:
 	default:
 		// os.O_RDONLY = 0
-		file = rwonly.ReadOnly(file)
+		file = rwonly.BlobReadOnly(file)
 	}
 
 	if flag&os.O_TRUNC != 0 {

--- a/internal/storer/fs.go
+++ b/internal/storer/fs.go
@@ -156,7 +156,7 @@ func (fs *Fs) OpenFile(name string, flag int, perm os.FileMode) (afFile afero.Fi
 	var file afero.File = storerFile
 	switch {
 	case flag&os.O_WRONLY != 0:
-		file = rwonly.WriteOnly(file)
+		file = rwonly.BlobWriteOnly(file)
 	case flag&os.O_RDWR != 0:
 	default:
 		// os.O_RDONLY = 0

--- a/internal/terminal/term.go
+++ b/internal/terminal/term.go
@@ -99,7 +99,7 @@ func pipe(files *fs.FileDescriptors) (r, w fs.FID) {
 }
 
 func readOutputPipes(term js.Value, files *fs.FileDescriptors, output fs.FID) {
-	buf := blob.NewJSLength(1)
+	buf := blob.NewWithLength(1)
 	for {
 		_, err := files.Read(output, buf, 0, buf.Len(), nil)
 		if err != nil {

--- a/main.go
+++ b/main.go
@@ -21,7 +21,7 @@ func main() {
 	global.Set("spawnTerminal", js.FuncOf(terminal.SpawnTerminal))
 	global.Set("dump", js.FuncOf(func(this js.Value, args []js.Value) interface{} {
 		go func() {
-			basePath := "/"
+			basePath := ""
 			if len(args) >= 1 {
 				basePath = args[0].String()
 				if filepath.IsAbs(basePath) {
@@ -30,7 +30,11 @@ func main() {
 					basePath = filepath.Join(libProcess.Current().WorkingDirectory(), basePath)
 				}
 			}
-			log.Error("Process:\n", process.Dump(), "\n\nFiles:\n", fs.Dump(basePath))
+			var fsDump interface{}
+			if basePath != "" {
+				fsDump = fs.Dump(basePath)
+			}
+			log.Error("Process:\n", process.Dump(), "\n\nFiles:\n", fsDump)
 		}()
 		return nil
 	}))

--- a/server/public/index.html
+++ b/server/public/index.html
@@ -3,7 +3,7 @@
   <head>
     <meta charset="utf-8" />
     <link rel="icon" href="%PUBLIC_URL%/favicon.ico" />
-    <meta name="viewport" content="width=device-width, initial-scale=1" />
+    <meta name="viewport" content="width=device-width, initial-scale=1, maximum-scale=1" />
     <meta name="theme-color" content="#000000" />
     <meta
       name="description"

--- a/server/src/GoWASM.js
+++ b/server/src/GoWASM.js
@@ -21,6 +21,8 @@ async function init() {
   const { goWasm, fs } = window
   console.debug(`go-wasm status: ${goWasm.ready ? 'ready' : 'not ready'}`)
 
+  await promisify(fs.mkdir, "/bin", {mode: 0o700})
+  await goWasm.overlayIndexedDB('/bin')
   await goWasm.overlayIndexedDB('/home/me')
   await promisify(fs.mkdir, "/home/me/.cache", {recursive: true, mode: 0o700})
   await goWasm.overlayIndexedDB('/home/me/.cache')


### PR DESCRIPTION
Lowers memory usage for running binaries like `go`, `compile`, and user programs.

Memory decreased by up to 56% in the best case and 47% in the worst case. The heap footprint should now remain below 250 MB in the worst case, down from 540 MB. On a second boot (not installing the Go toolchain), memory usage is reduced even further to below 180 MB. Execution times shortened a bit, but probably within margin of error.

See below for single samples of performance changes. These are super rough, so take them with a grain of salt.

Master branch:
* First boot:
    - Init = 59.04s; 297 MB heap
    - Compile = 179.18s
    - Run = 0.20s; 540 MB heap
* Second boot (after reload):
    - Init = 0.85s; 224 MB heap
    - Compile = 27.95s
    - Run = 0.12s; 394 MB heap

This PR:
* First boot:
	- Init = 64.35s; 156 MB heap `-47%`
	- Compile = 164.41s
	- Run = 0.13s; 245 MB heap `-55%`
* Second boot:
	- Init = 0.94s; 104 MB heap
	- Compile = 25.06s
	- Run = 0.10s; 175 MB heap `-56%`

I'd summarize the commits, but they were enough changes it'd probably be best to read through the commit messages themselves.