### PR TITLE
Fix overlapped vertical scrollbar

### DIFF
--- a/server/src/Editor.css
+++ b/server/src/Editor.css
@@ -4,7 +4,6 @@
 
 .editor .CodeMirror {
   height: 100%;
-  overflow-y: scroll;
 }
 
 .editor .CodeMirror-lines {


### PR DESCRIPTION
When one go beyond the editor viewport, the scrollbar overlaps the original one (which doesn't seem to have any utility). So, in order to avoid this situation, the 'original' vertical scrollbar has been remove.

Before: 
![before](https://user-images.githubusercontent.com/68973000/120734257-3061c700-c4ae-11eb-83b0-04a7f36b8d22.png)

After:
![after](https://user-images.githubusercontent.com/68973000/120734449-80408e00-c4ae-11eb-92b8-267b412d2a08.png)
