### PR TITLE
Add vet and cover tools

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -82,7 +82,7 @@ cache/go${GO_VERSION}: cache
 		mkdir -p ../bin/js_wasm; \
 		go build -o ../bin/js_wasm/ std cmd/go cmd/gofmt; \
 		go tool dist test -rebuild -list; \
-		go build -o ../pkg/tool/js_wasm/ std cmd/buildid cmd/pack; \
+		go build -o ../pkg/tool/js_wasm/ std cmd/buildid cmd/pack cmd/cover cmd/vet; \
 		go install ./...; \
 		popd; \
 		mv "$$TMP" cache/go${GO_VERSION}; \

--- a/cmd/sh/js_builtins.go
+++ b/cmd/sh/js_builtins.go
@@ -4,11 +4,13 @@ package main
 
 import (
 	"fmt"
+	"io/ioutil"
 	"strings"
 	"syscall/js"
 
 	"github.com/fatih/color"
 	"github.com/johnstarich/go-wasm/internal/console"
+	"github.com/johnstarich/go-wasm/internal/interop"
 	"github.com/johnstarich/go-wasm/internal/promise"
 	"github.com/pkg/errors"
 )
@@ -21,6 +23,7 @@ var (
 func init() {
 	builtins["jseval"] = jseval
 	builtins["wpk"] = wpk
+	builtins["jsdownload"] = jsdownload
 	color.NoColor = false // override, since wasm isn't considered a "tty"
 }
 
@@ -54,4 +57,17 @@ Installs a remote package by the name of 'pkg'.
 	default:
 		return errors.Errorf("Invalid command: %q", args[0])
 	}
+}
+
+func jsdownload(term console.Console, args ...string) error {
+	if len(args) < 1 {
+		return errors.New("Must provide a file to download")
+	}
+	filePath := args[0]
+	fileContents, err := ioutil.ReadFile(filePath)
+	if err != nil {
+		return errors.Wrap(err, "Error reading file for download")
+	}
+	interop.StartDownload("", filePath, fileContents)
+	return nil
 }

--- a/internal/interop/download.go
+++ b/internal/interop/download.go
@@ -15,6 +15,9 @@ var (
 )
 
 func StartDownload(contentType, fileName string, buf []byte) {
+	if contentType == "" {
+		contentType = "application/octet-stream"
+	}
 	b := blob.NewFromBytes(buf)
 	blobInstance := jsBlob.New([]interface{}{b}, map[string]interface{}{
 		"type": contentType,

--- a/internal/interop/profile.go
+++ b/internal/interop/profile.go
@@ -41,7 +41,7 @@ func TraceProfileJS(this js.Value, args []js.Value) interface{} {
 		log.Error("Failed to create memory profile: ", err)
 		return nil
 	}
-	StartDownload("application/octet-stream", "go-wasm-trace.pprof", buf)
+	StartDownload("", "go-wasm-trace.pprof", buf)
 	return nil
 }
 
@@ -61,7 +61,7 @@ func MemoryProfileJS(this js.Value, args []js.Value) interface{} {
 		log.Error("Failed to create memory profile: ", err)
 		return nil
 	}
-	StartDownload("application/octet-stream", "go-wasm-mem.pprof", buf)
+	StartDownload("", "go-wasm-mem.pprof", buf)
 	return nil
 }
 
@@ -75,7 +75,7 @@ func StartCPUProfile(ctx context.Context) error {
 	go func() {
 		<-ctx.Done()
 		pprof.StopCPUProfile()
-		StartDownload("application/octet-stream", "go-wasm-cpu.pprof", buf.Bytes())
+		StartDownload("", "go-wasm-cpu.pprof", buf.Bytes())
 	}()
 	return nil
 }


### PR DESCRIPTION
Add vet and cover `go tool` support.

Also add a `jsdownload` builtin command for the shell. This makes it possible to generate coverage files for Wasm-only tests and then parse them on your own machine.

i.e.
```bash
# in Go Wasm
go test ./... -coverprofile=cover.out
jsdownload cover.out
# locally
go tool cover -html cover.out
```

Perhaps eventually coverage can be fully integrated into the editor itself.